### PR TITLE
Fixed problem with printing the subtitle filename

### DIFF
--- a/subdl
+++ b/subdl
@@ -206,7 +206,7 @@ def DisplaySubtitleSearchResults(search_results):
                                                 rating.rjust(4),
                                                 downloads.rjust(downloads_maxlen),
                                                 moviename.ljust(moviename_maxlen),
-                                                filename)
+                                                filename.encode('utf8'))
 
 def DownloadSubtitle(sub_id):
     '''Download subtitle #sub_id and return subtitle text as string.'''


### PR DESCRIPTION
Displaying the subtitles filenames can fail when subtitles filename contain utf8 characters.
