### PR TITLE
Increase version number to 1.1.0

### DIFF
--- a/subdl
+++ b/subdl
@@ -50,7 +50,7 @@ Options:
   '''
 
 NAME = 'subdl'
-VERSION = '1.0.3'
+VERSION = '1.1.0'
 
 VERSION_INFO = '''\
 


### PR DESCRIPTION
Due to new features, I think there should be a new version. Specially since Arch and other distros will only update their packages in the event of a new version.