### PR TITLE
Print name of file the search results are for

### DIFF
--- a/subdl
+++ b/subdl
@@ -51,7 +51,7 @@ Options:
   '''
 
 NAME = 'subdl'
-VERSION = '1.1.0'
+VERSION = '1.1.1'
 
 VERSION_INFO = '''\
 

--- a/subdl
+++ b/subdl
@@ -231,8 +231,8 @@ def format_movie_name(s):
     s = s.replace('"', "'")
     return '"%s"' % s
 
-def DisplaySubtitleSearchResults(search_results):
-    print("Found %d results:" % (len(search_results)))
+def DisplaySubtitleSearchResults(search_results, file):
+    print("Found %d results for '%s':" % (len(search_results), file))
     idsubtitle_maxlen = 0
     moviename_maxlen = 0
     downloads_maxlen = 0
@@ -466,7 +466,7 @@ def main(args):
             no_search_results = no_search_results + 1
             continue
 
-        DisplaySubtitleSearchResults(search_results)
+        DisplaySubtitleSearchResults(search_results, file)
         if options.download == 'none':
             raise SystemExit
         elif options.download == 'first':


### PR DESCRIPTION
Problem: when I do `subdl -i *.mp4`, I am not sure which file the printed results are for, which makes it difficult to choose the subtitles. 

A solution is to show the file name before asking the user which subtitles to download, when in query mode:
```diff
diff --git a/subdl b/subdl
index 2f126a9..186c25a 100755
--- a/subdl
+++ b/subdl
@@ -481,6 +481,7 @@ def main(args):
             for search_result in search_results:
                 AutoDownloadAndSave(file, search_result, downloaded)
         elif options.download == 'query':
+            print("Search results for:", file)
             n = query_num("Enter result to download:",
                           1, len(search_results))
             AutoDownloadAndSave(file, search_results[n-1])
```

The solution I chose in this PR is to print the file name before listing the results, independently of the mode.

The second commit increases the version number in order to enable Linux distros to update their package for subdl if this change is merged. 