### PR TITLE
Fallback when glob fails

### DIFF
--- a/subdl.py
+++ b/subdl.py
@@ -372,7 +372,11 @@ def osdb_connect():
 def glob_arguments(args):
     arguments = []
     for arg in args:
-        arguments += glob.glob(arg, recursive=True)
+        glob_arg = glob.glob(arg, recursive=True)
+        if not glob_arg:
+            arguments += [ arg ]
+        else:
+            arguments += glob_arg
     return arguments
 
 def parseargs(args):


### PR DESCRIPTION
Non global argument is added to the list when glob.glob returns empty
array. This fixes an issue with glob_arguments returning empty list.