### PR TITLE
Remove bogus empty package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,5 @@ setup(
             'subdl = subdl:cli'
         ]
     },
-    packages=[
-        ''
-    ],
     license='GPLv3+'
 )


### PR DESCRIPTION
This empty package name is not valid, and results in `python setup.py build` and `python setup.py wheel` failing with:

    WARNING: '' not a valid package name; please use only .-separated package names in setup.py

Removing this entirely fixes the issue completely.